### PR TITLE
Naoki dsv1 update2

### DIFF
--- a/taketwo-dsmvp-v1.ipynb
+++ b/taketwo-dsmvp-v1.ipynb
@@ -2,6 +2,24 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#This is a variant of \"taketwo-dsmvp-v1-Feb9\" in this and the \"20newsgroup\" directory for the Jigsaw data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#It is also a variant of the version that was pushed to the main branch of TakeTwo repo in Feb 21. "
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],
@@ -29,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 97,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,99 +119,897 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 100,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Fetch data and store them in appropriate arrays"
+    "import pandas as pd"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 177,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import requests\n",
-    "\n",
-    "API_URL = <DB_URL>"
+    "import random"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 178,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#get the categories\n",
-    "response = requests.get(API_URL + \"categories\")\n",
-    "if response.status_code == 200:\n",
-    "    categories = [category[\"name\"] for category in response.json()]\n",
-    "    categories += [\"racial slur\"] #add additional not in the API manually"
+    "import string"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 101,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Fetch data and store them in appropriate arrays\n",
-    "response = requests.get(API_URL + \"mark\")\n",
-    "if response.status_code == 200:\n",
-    "    raw_data = response.json()\n",
-    "    \n",
-    "response.status_code"
+    "#Fetch the Jigsaw data and store them in appropriate arrays"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 102,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jigsawTrain = pd.read_csv('train.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 251,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1804874, 45)"
+      ]
+     },
+     "execution_count": 251,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jigsawTrain.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 403,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "allTrain = pd.DataFrame(jigsawTrain, columns = ['id', 'comment_text', 'severe_toxicity'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 404,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1804874, 3)"
+      ]
+     },
+     "execution_count": 404,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "allTrain.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 378,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "allTrain1M = allTrain.head(1000000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 379,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1000000, 3)"
+      ]
+     },
+     "execution_count": 379,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "allTrain1M.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 380,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#allTrain = allTrain1M"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "blackData = jigsawTrain[(jigsawTrain.black == 1.0)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 405,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1804874, 3)"
+      ]
+     },
+     "execution_count": 405,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "allTrain.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 104,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "blackTrain = pd.DataFrame(blackData, columns = ['id', 'comment_text', 'severe_toxicity', 'black'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 105,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(7656, 4)"
+      ]
+     },
+     "execution_count": 105,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "blackTrain.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 106,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "blackTrainId = blackTrain['id']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "blackTrainText = blackTrain['comment_text']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 108,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "blackTrainSevereToxicity = blackTrain.loc[:,'severe_toxicity']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 547,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "516    BJ, your suggestion that low income residents ...\n",
+       "Name: comment_text, dtype: object"
+      ]
+     },
+     "execution_count": 547,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "blackTrainText.head(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 406,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "allTrainId = allTrain['id']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 407,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "allTrainText = allTrain['comment_text']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 408,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "allTrainSevereToxicity = allTrain.loc[:,'severe_toxicity']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 409,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    0.000000\n",
+       "1    0.000000\n",
+       "2    0.000000\n",
+       "3    0.000000\n",
+       "4    0.021277\n",
+       "Name: severe_toxicity, dtype: float64"
+      ]
+     },
+     "execution_count": 409,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "allTrainSevereToxicity.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>comment_text</th>\n",
+       "      <th>severe_toxicity</th>\n",
+       "      <th>black</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>516</td>\n",
+       "      <td>240627</td>\n",
+       "      <td>BJ, your suggestion that low income residents ...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1428</td>\n",
+       "      <td>242346</td>\n",
+       "      <td>Well, this wasn't meant to be a dissertation. ...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1527</td>\n",
+       "      <td>242454</td>\n",
+       "      <td>So Hillary's appeal is to Democrats who make o...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1569</td>\n",
+       "      <td>242498</td>\n",
+       "      <td>Is the real point of this article to show that...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1623</td>\n",
+       "      <td>242562</td>\n",
+       "      <td>&gt; A less sensational headline would be “Black ...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          id                                       comment_text  \\\n",
+       "516   240627  BJ, your suggestion that low income residents ...   \n",
+       "1428  242346  Well, this wasn't meant to be a dissertation. ...   \n",
+       "1527  242454  So Hillary's appeal is to Democrats who make o...   \n",
+       "1569  242498  Is the real point of this article to show that...   \n",
+       "1623  242562  > A less sensational headline would be “Black ...   \n",
+       "\n",
+       "      severe_toxicity  black  \n",
+       "516               0.0    1.0  \n",
+       "1428              0.0    1.0  \n",
+       "1527              0.0    1.0  \n",
+       "1569              0.0    1.0  \n",
+       "1623              0.0    1.0  "
+      ]
+     },
+     "execution_count": 109,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "blackTrain.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 410,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>comment_text</th>\n",
+       "      <th>severe_toxicity</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>0</td>\n",
+       "      <td>59848</td>\n",
+       "      <td>This is so cool. It's like, 'would you want yo...</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>59849</td>\n",
+       "      <td>Thank you!! This would make my life a lot less...</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>2</td>\n",
+       "      <td>59852</td>\n",
+       "      <td>This is such an urgent design problem; kudos t...</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>3</td>\n",
+       "      <td>59855</td>\n",
+       "      <td>Is this something I'll be able to install on m...</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>4</td>\n",
+       "      <td>59856</td>\n",
+       "      <td>haha you guys are a bunch of losers.</td>\n",
+       "      <td>0.021277</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      id                                       comment_text  severe_toxicity\n",
+       "0  59848  This is so cool. It's like, 'would you want yo...         0.000000\n",
+       "1  59849  Thank you!! This would make my life a lot less...         0.000000\n",
+       "2  59852  This is such an urgent design problem; kudos t...         0.000000\n",
+       "3  59855  Is this something I'll be able to install on m...         0.000000\n",
+       "4  59856               haha you guys are a bunch of losers.         0.021277"
+      ]
+     },
+     "execution_count": 410,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "allTrain.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 110,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "240627"
+      ]
+     },
+     "execution_count": 110,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "blackTrainId.iloc[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 111,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"BJ, your suggestion that low income residents of Portland do not understand their own needs and desires perplexes me.  It is a bit snobby- as if the poor need middle class whites to tell them what they should want. And, for blacks and latinos, home ownership[ is pretty much their only chance for a nest egg.  Unless they are union they don't really get the jobs with stock options and generous 401k matches.  The fact that redlining once existed doesn't make the handful of black residents around Alberta less attached to their homes.\\n\\nYou are struggling with he fact that the working class folks in Portland do not want to live the New Urbanist dream.  Look at the big study Metro did to gauge housing preferences. \\n\\nFinally, I note you put a lot of trust in the people who own large apartment complexes to not exploit the inherent vulnerability that comes with being a renter.  The SFH gives people autonomy.  Yes, housing prices can drop, but so can any other investment.  Take my 401k- please...\""
+      ]
+     },
+     "execution_count": 111,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "blackTrainText.iloc[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 112,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 112,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "blackTrainSevereToxicity.iloc[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 189,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "7656"
+      ]
+     },
+     "execution_count": 189,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(blackTrain)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 411,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "categories = [\"non-toxic\", \"toxic\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 191,
    "metadata": {},
    "outputs": [],
    "source": [
     "from collections import namedtuple\n",
-    "data_set = namedtuple('data_set', [\"data\", \"urls\", \"target_names\", \"target\"])([],[],categories,[])\n",
-    "\n",
-    "for row in raw_data:\n",
-    "    if row['category'] in categories:\n",
-    "        data_set.data.append(row[\"flagged_string\"])\n",
-    "        data_set.urls.append(row[\"url\"])\n",
-    "        data_set.target.append(categories.index(row['category'])"
+    "data_set = namedtuple('data_set', [\"data\", \"urls\", \"target_names\", \"target\"])([],[],categories,[])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 193,
    "metadata": {},
    "outputs": [],
    "source": [
-    "marker_train = data_set"
+    "def flipCoin(bias):\n",
+    "    f = random.random()\n",
+    "    return True if f<bias else False"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 259,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "False\n",
+      "False\n",
+      "False\n",
+      "False\n",
+      "False\n",
+      "False\n",
+      "False\n",
+      "True\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i in range(0,10):\n",
+    "    print(flipCoin(0.25))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 195,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#For now using the same (training) data as the test data. Eventually, a separate test data set should be used."
+    "for x in range(len(blackTrain)):\n",
+    "    if (blackTrainSevereToxicity.iloc[x] > 0):\n",
+    "        data_set.target.append(1)\n",
+    "        data_set.urls.append(blackTrainId.iloc[x])\n",
+    "        data_set.data.append(blackTrainText.iloc[x])\n",
+    "    elif flipCoin(0.25):\n",
+    "        data_set.target.append(0)\n",
+    "        data_set.urls.append(blackTrainId.iloc[x])\n",
+    "        data_set.data.append(blackTrainText.iloc[x])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 480,
    "metadata": {},
    "outputs": [],
    "source": [
-    "marker_test = data_set"
+    "from collections import namedtuple\n",
+    "all_data_set = namedtuple('data_set', [\"data\", \"urls\", \"target_names\", \"target\"])([],[],categories,[])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 481,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "from collections import namedtuple\n",
+    "all_train_set = namedtuple('data_set', [\"data\", \"urls\", \"target_names\", \"target\"])([],[],categories,[])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 482,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from collections import namedtuple\n",
+    "all_test_set = namedtuple('data_set', [\"data\", \"urls\", \"target_names\", \"target\"])([],[],categories,[])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 483,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "downSampling = 0.06"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 484,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for x in range(len(allTrain)):\n",
+    "    if (allTrainSevereToxicity.iloc[x] > 0):\n",
+    "        all_data_set.target.append(1)\n",
+    "        all_data_set.urls.append(allTrainId.iloc[x])\n",
+    "        all_data_set.data.append(allTrainText.iloc[x])\n",
+    "    elif flipCoin(downSampling):\n",
+    "        all_data_set.target.append(0)\n",
+    "        all_data_set.urls.append(allTrainId.iloc[x])\n",
+    "        all_data_set.data.append(allTrainText.iloc[x])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 485,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Here is a version in which training and test data are separately generated from all data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 486,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainRatio = 0.9"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 487,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for x in range(len(allTrain)):\n",
+    "    if (allTrainSevereToxicity.iloc[x] > 0):\n",
+    "        if flipCoin(trainRatio): \n",
+    "            all_train_set.target.append(1)\n",
+    "            all_train_set.urls.append(allTrainId.iloc[x])\n",
+    "            all_train_set.data.append(allTrainText.iloc[x])\n",
+    "        else: \n",
+    "            all_test_set.target.append(1)\n",
+    "            all_test_set.urls.append(allTrainId.iloc[x])\n",
+    "            all_test_set.data.append(allTrainText.iloc[x])\n",
+    "    elif flipCoin(downSampling):\n",
+    "        if flipCoin(trainRatio): \n",
+    "            all_train_set.target.append(0)\n",
+    "            all_train_set.urls.append(allTrainId.iloc[x])\n",
+    "            all_train_set.data.append(allTrainText.iloc[x])\n",
+    "        else: \n",
+    "            all_test_set.target.append(0)\n",
+    "            all_test_set.urls.append(allTrainId.iloc[x])\n",
+    "            all_test_set.data.append(allTrainText.iloc[x])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 488,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#either leave data_set as is (generated from blackData) or set it to all_data_set (generated from all the data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 493,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_set = all_test_set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 494,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "20810"
+      ]
+     },
+     "execution_count": 494,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(data_set.target)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 495,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0, 0, 1, 1, 0, 0, 1, 1, 0, 1]"
+      ]
+     },
+     "execution_count": 495,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    " data_set.target[0:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 496,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10597"
+      ]
+     },
+     "execution_count": 496,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sum(data_set.target)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 428,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[59856, 59859, 59861, 239583, 239607, 239612, 239655, 239711, 239733, 239762]"
+      ]
+     },
+     "execution_count": 428,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_set.urls[0:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 429,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['haha you guys are a bunch of losers.', 'ur a sh*tty comment.']"
+      ]
+     },
+     "execution_count": 429,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_set.data[0:2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 497,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "marker_train = all_train_set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 498,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Here a separate test data set should be used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 499,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "marker_test = all_test_set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 500,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "toxic\n",
+      "toxic\n",
+      "toxic\n",
+      "non-toxic\n",
+      "toxic\n",
+      "toxic\n",
+      "non-toxic\n",
+      "non-toxic\n",
+      "toxic\n",
+      "non-toxic\n"
+     ]
+    }
+   ],
    "source": [
     "for t in marker_train.target[:10]:\n",
     "...     print(marker_train.target_names[t])"
@@ -201,7 +1017,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 501,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,7 +1026,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 502,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,7 +1035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 503,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +1044,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 504,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,56 +1054,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 505,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(2257,)"
+       "185473"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 505,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "marker_train.target.shape"
+    "len(marker_train.target)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 506,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(1502,)"
+       "94039"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 506,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "marker_test.target.shape"
+    "sum(marker_train.target)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 507,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "1502"
+       "20810"
       ]
      },
-     "execution_count": 80,
+     "execution_count": 507,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -298,23 +1114,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 508,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "comp.graphics\n",
-      "comp.graphics\n",
-      "soc.religion.christian\n",
-      "soc.religion.christian\n",
-      "soc.religion.christian\n",
-      "soc.religion.christian\n",
-      "soc.religion.christian\n",
-      "sci.med\n",
-      "sci.med\n",
-      "sci.med\n"
+      "toxic\n",
+      "toxic\n",
+      "toxic\n",
+      "non-toxic\n",
+      "toxic\n",
+      "toxic\n",
+      "non-toxic\n",
+      "non-toxic\n",
+      "toxic\n",
+      "non-toxic\n"
      ]
     }
    ],
@@ -325,23 +1141,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 509,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "sci.med\n",
-      "sci.med\n",
-      "sci.med\n",
-      "alt.atheism\n",
-      "soc.religion.christian\n",
-      "alt.atheism\n",
-      "comp.graphics\n",
-      "soc.religion.christian\n",
-      "sci.med\n",
-      "sci.med\n"
+      "non-toxic\n",
+      "non-toxic\n",
+      "toxic\n",
+      "toxic\n",
+      "non-toxic\n",
+      "non-toxic\n",
+      "toxic\n",
+      "toxic\n",
+      "non-toxic\n",
+      "toxic\n"
      ]
     }
    ],
@@ -352,7 +1168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 510,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,7 +1179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 511,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,7 +1199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 512,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +1213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 513,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -406,7 +1222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 514,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +1246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 515,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -447,7 +1263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 516,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -456,7 +1272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 517,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,7 +1288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 518,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -481,7 +1297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 519,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +1306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 520,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -499,7 +1315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 521,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -508,7 +1324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 522,
    "metadata": {},
    "outputs": [
     {
@@ -517,7 +1333,7 @@
        "MultinomialNB(alpha=1.0, class_prior=None, fit_prior=True)"
       ]
      },
-     "execution_count": 95,
+     "execution_count": 522,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -528,7 +1344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 523,
    "metadata": {},
    "outputs": [
     {
@@ -542,7 +1358,7 @@
        "                tokenizer=None, vocabulary=None)"
       ]
      },
-     "execution_count": 96,
+     "execution_count": 523,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -553,7 +1369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 524,
    "metadata": {},
    "outputs": [
     {
@@ -562,7 +1378,7 @@
        "TfidfTransformer(norm='l2', smooth_idf=True, sublinear_tf=False, use_idf=False)"
       ]
      },
-     "execution_count": 97,
+     "execution_count": 524,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -573,7 +1389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 525,
    "metadata": {},
    "outputs": [
     {
@@ -582,7 +1398,7 @@
        "MultinomialNB(alpha=1.0, class_prior=None, fit_prior=True)"
       ]
      },
-     "execution_count": 98,
+     "execution_count": 525,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -593,7 +1409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 526,
    "metadata": {},
    "outputs": [
     {
@@ -607,7 +1423,7 @@
        "                tokenizer=None, vocabulary=None)"
       ]
      },
-     "execution_count": 99,
+     "execution_count": 526,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -618,7 +1434,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 527,
    "metadata": {},
    "outputs": [
     {
@@ -627,7 +1443,7 @@
        "TfidfTransformer(norm='l2', smooth_idf=True, sublinear_tf=False, use_idf=False)"
       ]
      },
-     "execution_count": 100,
+     "execution_count": 527,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -638,7 +1454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 528,
    "metadata": {},
    "outputs": [
     {
@@ -667,7 +1483,7 @@
        "         verbose=False)"
       ]
      },
-     "execution_count": 101,
+     "execution_count": 528,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -678,7 +1494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 529,
    "metadata": {},
    "outputs": [
     {
@@ -692,7 +1508,7 @@
        "                tokenizer=None, vocabulary=None)"
       ]
      },
-     "execution_count": 102,
+     "execution_count": 529,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -703,7 +1519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 530,
    "metadata": {},
    "outputs": [
     {
@@ -712,7 +1528,7 @@
        "TfidfTransformer(norm='l2', smooth_idf=True, sublinear_tf=False, use_idf=False)"
       ]
      },
-     "execution_count": 103,
+     "execution_count": 530,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -723,7 +1539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 531,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -732,7 +1548,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 532,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -741,7 +1557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 533,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -750,7 +1566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 534,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -759,16 +1575,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 535,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([1])"
+       "array([0])"
       ]
      },
-     "execution_count": 108,
+     "execution_count": 535,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -779,16 +1595,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": 536,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([1])"
+       "array([0])"
       ]
      },
-     "execution_count": 109,
+     "execution_count": 536,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -799,7 +1615,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 537,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -808,7 +1624,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 538,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -817,7 +1633,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": 539,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -826,16 +1642,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 540,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(1502,)"
+       "(20810,)"
       ]
      },
-     "execution_count": 113,
+     "execution_count": 540,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -846,36 +1662,1076 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": 541,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([2, 2, 2, ..., 2, 2, 1])"
+       "9332"
       ]
      },
-     "execution_count": 114,
+     "execution_count": 541,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "predicted_test_SGD"
+    "sum(predicted_test_SGD)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": 542,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([2, 2, 2, ..., 2, 2, 1])"
+       "11385"
       ]
      },
-     "execution_count": 115,
+     "execution_count": 542,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sum(predicted_test_NB)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 543,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0])"
+      ]
+     },
+     "execution_count": 543,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predicted_test_SGD[0:20]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 544,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 0,\n",
+       " 1,\n",
+       " ...]"
+      ]
+     },
+     "execution_count": 544,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -886,16 +2742,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": 545,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.7669773635153129"
+       "0.7641518500720808"
       ]
      },
-     "execution_count": 116,
+     "execution_count": 545,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -906,16 +2762,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 546,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.9101198402130493"
+       "0.7134550696780394"
       ]
      },
-     "execution_count": 117,
+     "execution_count": 546,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/taketwo-dsmvp-v1.ipynb
+++ b/taketwo-dsmvp-v1.ipynb
@@ -2,29 +2,11 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#This is a variant of \"taketwo-dsmvp-v1-Feb9\" in this and the \"20newsgroup\" directory for the Jigsaw data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#It is also a variant of the version that was pushed to the main branch of TakeTwo repo in Feb 21. "
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#This is an attempt for the final version of \"v1\", eventually to work with the repo data"
+    "#This is a variant of \"taketwo-dsmvp-v1\" for the Jigsaw data."
    ]
   },
   {
@@ -33,21 +15,66 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#This version contains both NB (Naive Bayes) and SGD (Support Vector Machine)"
+    "#It is also a variant of the version that was pushed to the main branch of TakeTwo repo in Feb 21. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#In this version, the 20newsgroup data are being used for now. "
+    "#This is a version of \"v1\" demo notebook."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#CODE DEPENDENCY: sklearn, numpy, pandas, random, string. It uses from sklearn NB (Naive Bayes) and SGD (Support Vector Machine)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#DATA DEPENDENCY: In this version the \"Jigsaw unintended biased in toxicity\" data is used for demo purpose. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#See https://www.kaggle.com/c/jigsaw-unintended-bias-in-toxicity-classification/data?select=train.csv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#for detailed description of the data and instructions to download them. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#As of now we are using only the \"train.csv\" portion of the data, which needs to be in the calling directory. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 177,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 251,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -173,7 +200,7 @@
        "(1804874, 45)"
       ]
      },
-     "execution_count": 251,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -184,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 403,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 404,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -202,7 +229,7 @@
        "(1804874, 3)"
       ]
      },
-     "execution_count": 404,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -213,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 378,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,7 +249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 379,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -231,7 +258,7 @@
        "(1000000, 3)"
       ]
      },
-     "execution_count": 379,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -242,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 380,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 405,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -269,7 +296,7 @@
        "(1804874, 3)"
       ]
      },
-     "execution_count": 405,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -280,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -298,7 +325,7 @@
        "(7656, 4)"
       ]
      },
-     "execution_count": 105,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -309,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,7 +354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -336,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 547,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -346,7 +373,7 @@
        "Name: comment_text, dtype: object"
       ]
      },
-     "execution_count": 547,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -357,7 +384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 406,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -366,7 +393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 407,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,7 +402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 408,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -384,7 +411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 409,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -398,7 +425,7 @@
        "Name: severe_toxicity, dtype: float64"
       ]
      },
-     "execution_count": 409,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -409,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -495,7 +522,7 @@
        "1623              0.0    1.0  "
       ]
      },
-     "execution_count": 109,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -506,7 +533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 410,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -579,7 +606,7 @@
        "4  59856               haha you guys are a bunch of losers.         0.021277"
       ]
      },
-     "execution_count": 410,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -590,7 +617,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -599,7 +626,7 @@
        "240627"
       ]
      },
-     "execution_count": 110,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -610,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -619,7 +646,7 @@
        "\"BJ, your suggestion that low income residents of Portland do not understand their own needs and desires perplexes me.  It is a bit snobby- as if the poor need middle class whites to tell them what they should want. And, for blacks and latinos, home ownership[ is pretty much their only chance for a nest egg.  Unless they are union they don't really get the jobs with stock options and generous 401k matches.  The fact that redlining once existed doesn't make the handful of black residents around Alberta less attached to their homes.\\n\\nYou are struggling with he fact that the working class folks in Portland do not want to live the New Urbanist dream.  Look at the big study Metro did to gauge housing preferences. \\n\\nFinally, I note you put a lot of trust in the people who own large apartment complexes to not exploit the inherent vulnerability that comes with being a renter.  The SFH gives people autonomy.  Yes, housing prices can drop, but so can any other investment.  Take my 401k- please...\""
       ]
      },
-     "execution_count": 111,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -630,7 +657,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -639,7 +666,7 @@
        "0.0"
       ]
      },
-     "execution_count": 112,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -650,7 +677,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 189,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -659,7 +686,7 @@
        "7656"
       ]
      },
-     "execution_count": 189,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -670,7 +697,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 411,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -679,7 +706,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 191,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -689,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 193,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -700,7 +727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 259,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -716,7 +743,7 @@
       "False\n",
       "False\n",
       "True\n",
-      "True\n"
+      "False\n"
      ]
     }
    ],
@@ -727,7 +754,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 195,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -744,7 +771,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 480,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -754,7 +781,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 481,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -764,7 +791,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 482,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -774,7 +801,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 483,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -783,7 +810,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 484,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -800,7 +827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 485,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -809,7 +836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 486,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -818,7 +845,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 487,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -845,7 +872,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 488,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -854,7 +881,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 493,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -863,16 +890,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 494,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "20810"
+       "20686"
       ]
      },
-     "execution_count": 494,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -883,16 +910,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 495,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[0, 0, 1, 1, 0, 0, 1, 1, 0, 1]"
+       "[1, 0, 0, 0, 0, 1, 1, 1, 0, 0]"
       ]
      },
-     "execution_count": 495,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -903,16 +930,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 496,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "10597"
+       "10432"
       ]
      },
-     "execution_count": 496,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -923,16 +950,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 428,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[59856, 59859, 59861, 239583, 239607, 239612, 239655, 239711, 239733, 239762]"
+       "[59856, 239656, 240391, 240422, 240853, 240941, 241214, 241346, 241370, 242261]"
       ]
      },
-     "execution_count": 428,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -943,16 +970,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 429,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['haha you guys are a bunch of losers.', 'ur a sh*tty comment.']"
+       "['haha you guys are a bunch of losers.',\n",
+       " \"I've been loosely following Civil Comments since it was announced late last year; I even tried a beta demonstration. One thing I've been wondering is: will users will have to sign up for new profiles on any site that uses Civil, or do you have one Civil profile that you'd use on any partner site?\"]"
       ]
      },
-     "execution_count": 429,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -963,7 +991,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 497,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -972,7 +1000,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 498,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -981,7 +1009,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 499,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -990,7 +1018,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 500,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [
     {
@@ -1000,13 +1028,13 @@
       "toxic\n",
       "toxic\n",
       "toxic\n",
-      "non-toxic\n",
       "toxic\n",
       "toxic\n",
       "non-toxic\n",
       "non-toxic\n",
-      "toxic\n",
-      "non-toxic\n"
+      "non-toxic\n",
+      "non-toxic\n",
+      "toxic\n"
      ]
     }
    ],
@@ -1017,7 +1045,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 501,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1026,7 +1054,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 502,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1035,7 +1063,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 503,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1044,26 +1072,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 504,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#flagger_new_text = fetch_20newsgroups(subset='test',\n",
-    "#                                      categories=categories, shuffle=True, random_state=42)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 505,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "185473"
+       "186150"
       ]
      },
-     "execution_count": 505,
+     "execution_count": 74,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1074,16 +1092,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 506,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "94039"
+       "94204"
       ]
      },
-     "execution_count": 506,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1094,16 +1112,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 507,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "20810"
+       "20686"
       ]
      },
-     "execution_count": 507,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1114,7 +1132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 508,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [
     {
@@ -1124,13 +1142,13 @@
       "toxic\n",
       "toxic\n",
       "toxic\n",
-      "non-toxic\n",
       "toxic\n",
       "toxic\n",
       "non-toxic\n",
       "non-toxic\n",
-      "toxic\n",
-      "non-toxic\n"
+      "non-toxic\n",
+      "non-toxic\n",
+      "toxic\n"
      ]
     }
    ],
@@ -1141,23 +1159,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 509,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "toxic\n",
+      "non-toxic\n",
+      "non-toxic\n",
       "non-toxic\n",
       "non-toxic\n",
       "toxic\n",
       "toxic\n",
-      "non-toxic\n",
-      "non-toxic\n",
-      "toxic\n",
       "toxic\n",
       "non-toxic\n",
-      "toxic\n"
+      "non-toxic\n"
      ]
     }
    ],
@@ -1168,7 +1186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 510,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1179,7 +1197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 511,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1199,7 +1217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 512,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1213,7 +1231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 513,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1222,7 +1240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 514,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1246,7 +1264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 515,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1263,7 +1281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 516,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1272,7 +1290,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 517,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1288,7 +1306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 518,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1297,7 +1315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 519,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1306,7 +1324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 520,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1315,7 +1333,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 521,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1324,7 +1342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 522,
+   "execution_count": 91,
    "metadata": {},
    "outputs": [
     {
@@ -1333,7 +1351,7 @@
        "MultinomialNB(alpha=1.0, class_prior=None, fit_prior=True)"
       ]
      },
-     "execution_count": 522,
+     "execution_count": 91,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1344,7 +1362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 523,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [
     {
@@ -1358,7 +1376,7 @@
        "                tokenizer=None, vocabulary=None)"
       ]
      },
-     "execution_count": 523,
+     "execution_count": 92,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1369,7 +1387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 524,
+   "execution_count": 93,
    "metadata": {},
    "outputs": [
     {
@@ -1378,7 +1396,7 @@
        "TfidfTransformer(norm='l2', smooth_idf=True, sublinear_tf=False, use_idf=False)"
       ]
      },
-     "execution_count": 524,
+     "execution_count": 93,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1389,7 +1407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 525,
+   "execution_count": 94,
    "metadata": {},
    "outputs": [
     {
@@ -1398,7 +1416,7 @@
        "MultinomialNB(alpha=1.0, class_prior=None, fit_prior=True)"
       ]
      },
-     "execution_count": 525,
+     "execution_count": 94,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1409,7 +1427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 526,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [
     {
@@ -1423,7 +1441,7 @@
        "                tokenizer=None, vocabulary=None)"
       ]
      },
-     "execution_count": 526,
+     "execution_count": 95,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1434,7 +1452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 527,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [
     {
@@ -1443,7 +1461,7 @@
        "TfidfTransformer(norm='l2', smooth_idf=True, sublinear_tf=False, use_idf=False)"
       ]
      },
-     "execution_count": 527,
+     "execution_count": 96,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1454,7 +1472,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 528,
+   "execution_count": 97,
    "metadata": {},
    "outputs": [
     {
@@ -1483,7 +1501,7 @@
        "         verbose=False)"
       ]
      },
-     "execution_count": 528,
+     "execution_count": 97,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1494,7 +1512,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 529,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [
     {
@@ -1508,7 +1526,7 @@
        "                tokenizer=None, vocabulary=None)"
       ]
      },
-     "execution_count": 529,
+     "execution_count": 98,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1519,7 +1537,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 530,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [
     {
@@ -1528,7 +1546,7 @@
        "TfidfTransformer(norm='l2', smooth_idf=True, sublinear_tf=False, use_idf=False)"
       ]
      },
-     "execution_count": 530,
+     "execution_count": 99,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1539,7 +1557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 531,
+   "execution_count": 100,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1548,16 +1566,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 532,
+   "execution_count": 101,
    "metadata": {},
    "outputs": [],
    "source": [
-    "flagger_new_text = ['OpenGL on the GPU is fast']"
+    "#flagger_new_text = fetch_20newsgroups(subset='test',\n",
+    "#                                      categories=categories, shuffle=True, random_state=42)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 533,
+   "execution_count": 106,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flagger_new_text = ['haha you guys are a bunch of losers.']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1566,7 +1594,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 534,
+   "execution_count": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1575,16 +1603,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 535,
+   "execution_count": 109,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([0])"
+       "array([1])"
       ]
      },
-     "execution_count": 535,
+     "execution_count": 109,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1595,16 +1623,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 536,
+   "execution_count": 110,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([0])"
+       "array([1])"
       ]
      },
-     "execution_count": 536,
+     "execution_count": 110,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1615,7 +1643,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 537,
+   "execution_count": 111,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1624,7 +1652,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 538,
+   "execution_count": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1633,7 +1661,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 539,
+   "execution_count": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1642,16 +1670,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 540,
+   "execution_count": 114,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(20810,)"
+       "(20686,)"
       ]
      },
-     "execution_count": 540,
+     "execution_count": 114,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1662,16 +1690,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 541,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "9332"
+       "9073"
       ]
      },
-     "execution_count": 541,
+     "execution_count": 115,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1682,16 +1710,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 542,
+   "execution_count": 116,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "11385"
+       "11098"
       ]
      },
-     "execution_count": 542,
+     "execution_count": 116,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1702,16 +1730,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 543,
+   "execution_count": 117,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0])"
+       "array([1, 0, 0, 0, 1, 1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0])"
       ]
      },
-     "execution_count": 543,
+     "execution_count": 117,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1722,111 +1750,106 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 544,
+   "execution_count": 118,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[0,\n",
+       "[1,\n",
        " 0,\n",
-       " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
-       " 1,\n",
+       " 0,\n",
+       " 0,\n",
        " 0,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
-       " 0,\n",
-       " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 1,\n",
+       " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
-       " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
-       " 1,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
-       " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
@@ -1838,40 +1861,44 @@
        " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
-       " 1,\n",
        " 0,\n",
-       " 1,\n",
+       " 0,\n",
+       " 0,\n",
        " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
        " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 0,\n",
        " 1,\n",
+       " 0,\n",
+       " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
-       " 0,\n",
-       " 0,\n",
-       " 0,\n",
        " 1,\n",
        " 0,\n",
-       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
+       " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
@@ -1879,124 +1906,114 @@
        " 0,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
-       " 0,\n",
-       " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
-       " 0,\n",
-       " 0,\n",
-       " 0,\n",
        " 1,\n",
-       " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
-       " 1,\n",
-       " 1,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
-       " 0,\n",
-       " 1,\n",
        " 1,\n",
-       " 0,\n",
-       " 0,\n",
        " 1,\n",
-       " 0,\n",
-       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 0,\n",
        " 1,\n",
-       " 0,\n",
-       " 0,\n",
-       " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
+       " 0,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
-       " 0,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
@@ -2004,78 +2021,82 @@
        " 1,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
-       " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 0,\n",
-       " 0,\n",
-       " 1,\n",
-       " 1,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
-       " 0,\n",
-       " 1,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
+       " 0,\n",
+       " 1,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
+       " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
-       " 1,\n",
+       " 0,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
@@ -2084,45 +2105,41 @@
        " 0,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
-       " 0,\n",
-       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
-       " 1,\n",
+       " 0,\n",
+       " 0,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
@@ -2131,13 +2148,9 @@
        " 0,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
        " 1,\n",
-       " 0,\n",
-       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
@@ -2145,28 +2158,44 @@
        " 1,\n",
        " 1,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
+       " 0,\n",
+       " 0,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
+       " 0,\n",
+       " 0,\n",
        " 0,\n",
        " 1,\n",
+       " 0,\n",
+       " 0,\n",
        " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
+       " 0,\n",
+       " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
@@ -2175,77 +2204,99 @@
        " 1,\n",
        " 1,\n",
        " 0,\n",
-       " 1,\n",
-       " 1,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
-       " 1,\n",
+       " 0,\n",
+       " 0,\n",
        " 1,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
+       " 0,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
+       " 1,\n",
+       " 0,\n",
+       " 0,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
-       " 0,\n",
+       " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
@@ -2259,45 +2310,47 @@
        " 1,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
-       " 1,\n",
        " 0,\n",
-       " 1,\n",
-       " 1,\n",
-       " 1,\n",
+       " 0,\n",
        " 0,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
+       " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
-       " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
@@ -2305,21 +2358,20 @@
        " 1,\n",
        " 0,\n",
        " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
-       " 1,\n",
+       " 0,\n",
+       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
@@ -2328,51 +2380,49 @@
        " 1,\n",
        " 1,\n",
        " 1,\n",
+       " 0,\n",
+       " 0,\n",
+       " 1,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 1,\n",
        " 1,\n",
-       " 1,\n",
-       " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
-       " 1,\n",
-       " 0,\n",
        " 0,\n",
+       " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
-       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
@@ -2382,20 +2432,20 @@
        " 1,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
+       " 1,\n",
        " 1,\n",
        " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
-       " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
@@ -2404,27 +2454,24 @@
        " 0,\n",
        " 1,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
-       " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
-       " 1,\n",
        " 1,\n",
        " 0,\n",
+       " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
@@ -2434,19 +2481,28 @@
        " 0,\n",
        " 1,\n",
        " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 0,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
+       " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
@@ -2455,102 +2511,90 @@
        " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 1,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 1,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 1,\n",
-       " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
-       " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
-       " 1,\n",
-       " 1,\n",
        " 1,\n",
-       " 1,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
-       " 1,\n",
-       " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
@@ -2558,180 +2602,164 @@
        " 0,\n",
        " 0,\n",
        " 1,\n",
-       " 0,\n",
-       " 0,\n",
-       " 0,\n",
        " 0,\n",
-       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 0,\n",
-       " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
+       " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 1,\n",
+       " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 0,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
+       " 1,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
+       " 1,\n",
        " 0,\n",
+       " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
-       " 0,\n",
-       " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
-       " 0,\n",
-       " 0,\n",
        " 0,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
-       " 1,\n",
-       " 0,\n",
-       " 0,\n",
        " 0,\n",
        " 0,\n",
-       " 0,\n",
+       " 1,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 0,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
-       " 0,\n",
        " 1,\n",
        " 1,\n",
-       " 0,\n",
-       " 0,\n",
        " 0,\n",
        " 0,\n",
-       " 0,\n",
-       " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
-       " 1,\n",
        " 1,\n",
        " 1,\n",
-       " 1,\n",
-       " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
-       " 1,\n",
+       " 0,\n",
        " 1,\n",
+       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 1,\n",
        " 1,\n",
        " 0,\n",
        " 1,\n",
-       " 0,\n",
-       " 0,\n",
-       " 0,\n",
        " 1,\n",
        " 0,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
+       " 1,\n",
        " 0,\n",
        " 0,\n",
        " 1,\n",
-       " 1,\n",
        " 0,\n",
        " 0,\n",
-       " 1,\n",
        " 0,\n",
        " 1,\n",
        " ...]"
       ]
      },
-     "execution_count": 544,
+     "execution_count": 118,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2742,16 +2770,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 545,
+   "execution_count": 119,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.7641518500720808"
+       "0.7597408875568017"
       ]
      },
-     "execution_count": 545,
+     "execution_count": 119,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2762,16 +2790,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 546,
+   "execution_count": 120,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.7134550696780394"
+       "0.7130909794063618"
       ]
      },
-     "execution_count": 546,
+     "execution_count": 120,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
The notebook "taketwo-dsmvp-v1.ipynb" has been modified to include a run with the Jigsaw "unintended bias in toxicity classification" data (c.f. https://www.kaggle.com/c/jigsaw-unintended-bias-in-toxicity-classification/data?select=train.csv). 

A brief comment regarding this DATA DEPENDENCY as well as CODE DEPENDENCY have been added. 

Though this is still a preliminary notebook, and re-factoring (e.g. by defining Python classes such as Model, Data, etc.) would be desirable in future versions, it is a better demo version than the existing version of the same notebook in the main branch, and should do the job for now. 